### PR TITLE
fix: set editor as first responder after new document creation

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -3094,7 +3094,8 @@ static void removeMacroFromShortcutsXML(NSString *name) {
 #pragma mark - File menu actions
 
 - (void)newDocument:(id)sender {
-    [_tabManager addNewTab];
+    EditorView *ed = [_tabManager addNewTab];
+    [self.window makeFirstResponder:ed.scintillaView];
     [self updateTitle];
 }
 


### PR DESCRIPTION
## Summary

Fixes the crash reported in #19 — consistently reproducible by:
1. Creating a new document (Cmd+N or File → New)
2. Immediately pressing Cmd+V to paste before clicking into the editor

## Root cause

`newDocument:` called `[_tabManager addNewTab]` but never transferred keyboard focus to the new editor's `ScintillaView`. When the user immediately pressed Cmd+V, the paste action was dispatched into the responder chain with no focused editor to receive it, causing a crash.

## Fix

One line added — capture the returned `EditorView *` and call `makeFirstResponder:` on its `scintillaView`. This is identical to the pattern already used in `_tabControlNew:` (line 2308) and six other call sites in this file.

```objc
// Before
- (void)newDocument:(id)sender {
    [_tabManager addNewTab];
    [self updateTitle];
}

// After
- (void)newDocument:(id)sender {
    EditorView *ed = [_tabManager addNewTab];
    [self.window makeFirstResponder:ed.scintillaView];
    [self updateTitle];
}
```

## Test plan

- [ ] Cmd+N → immediately Cmd+V → no crash, text pastes correctly
- [ ] Cmd+N → click editor → Cmd+V → still works as before
- [ ] New tab via toolbar button → still works (separate code path, unchanged)
- [ ] Open existing file → focus still lands on editor correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)