### PR TITLE
feat: zoom with Ctrl + scroll wheel over editor

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -1458,6 +1458,10 @@ static NSDictionary<NSString *, NSArray *> *toolbarGroupMap(void) {
     BOOL _showIndentGuides;
     BOOL _showLineNumbers;
 
+    // Ctrl + scroll-wheel zoom
+    id      _scrollZoomEventMonitor;
+    CGFloat _scrollZoomAccumulator;
+
     // Scroll synchronization
     BOOL _syncVerticalScrolling;
     BOOL _syncHorizontalScrolling;
@@ -1540,11 +1544,55 @@ static NSDictionary<NSString *, NSArray *> *toolbarGroupMap(void) {
                                                         selector:@selector(autoSaveTick:)
                                                         userInfo:nil
                                                          repeats:YES];
+        [self _installScrollZoomMonitor];
     }
     return self;
 }
 
+- (void)_installScrollZoomMonitor {
+    __weak typeof(self) weakSelf = self;
+    _scrollZoomEventMonitor =
+        [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskScrollWheel
+                                              handler:^NSEvent *(NSEvent *event) {
+        // Only intercept Control + scroll
+        if (!(event.modifierFlags & NSEventModifierFlagControl)) return event;
+
+        __strong typeof(weakSelf) self = weakSelf;
+        if (!self) return event;
+
+        // Confirm the pointer is over one of our editor views
+        NSPoint loc = [self.window.contentView convertPoint:event.locationInWindow fromView:nil];
+        NSView *hit = [self.window.contentView hitTest:loc];
+        BOOL inEditor = NO;
+        for (NSView *v = hit; v; v = v.superview) {
+            if ([v isKindOfClass:[EditorView class]]) { inEditor = YES; break; }
+        }
+        if (!inEditor) return event;
+
+        CGFloat delta;
+        if (event.hasPreciseScrollingDeltas) {
+            // Trackpad: accumulate small per-event deltas; fire once per threshold crossed
+            self->_scrollZoomAccumulator += event.scrollingDeltaY;
+            if (fabs(self->_scrollZoomAccumulator) < 8.0) return nil;
+            delta = self->_scrollZoomAccumulator;
+            self->_scrollZoomAccumulator = 0.0;
+        } else {
+            // Discrete mouse wheel: one notch = one zoom step
+            delta = event.deltaY;
+        }
+
+        if      (delta > 0) [self zoomIn:nil];
+        else if (delta < 0) [self zoomOut:nil];
+
+        return nil; // consume — do not scroll the editor
+    }];
+}
+
 - (void)dealloc {
+    if (_scrollZoomEventMonitor) {
+        [NSEvent removeMonitor:_scrollZoomEventMonitor];
+        _scrollZoomEventMonitor = nil;
+    }
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 


### PR DESCRIPTION
## Summary

Implements the Ctrl + mouse wheel zoom shortcut requested in #5, matching the Windows Notepad++ behaviour.

- **Discrete mouse wheel** — one notch zooms one step in or out
- **Trackpad (precise deltas)** — small per-event deltas are accumulated; a zoom step fires once the running total exceeds 8 pt, then resets (prevents runaway zooming on fast swipes)

## Implementation

A single `NSEvent` local monitor is installed in `MainWindowController` at init time and torn down in `dealloc`. It intercepts scroll-wheel events that carry the `NSEventModifierFlagControl` modifier **and** land over an `EditorView` (confirmed by hit-testing). Qualifying events are forwarded to the existing `zoomIn:` / `zoomOut:` actions — no zoom logic is duplicated — and then consumed so the document does not also scroll.

The change is 48 lines across one file (`MainWindowController.mm`):
- Two new ivars (`_scrollZoomEventMonitor`, `_scrollZoomAccumulator`)
- A private `-_installScrollZoomMonitor` method wired into `init`
- Monitor teardown added to `dealloc`

## Test plan

- [ ] Ctrl + scroll up over editor → text zooms in one step per wheel notch
- [ ] Ctrl + scroll down over editor → text zooms out one step per wheel notch
- [ ] Trackpad: slow Ctrl + swipe up → zooms in (not on every tiny event)
- [ ] Trackpad: fast Ctrl + swipe → zooms a reasonable number of steps, not dozens
- [ ] Scroll without Ctrl held → normal document scrolling, no zoom
- [ ] Ctrl + scroll over a panel (Find bar, side panel) → no zoom, event passes through
- [ ] Cmd+= / Cmd+- toolbar zoom buttons still work independently
- [ ] Zoom level persists after restart (stored in `kPrefZoomLevel` by existing `zoomIn:`/`zoomOut:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)