### PR TITLE
Fix macOS build failure caused by mixed ar/ranlib toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
 project(NotepadPlusPlusMac OBJCXX CXX C)
 
+if(APPLE)
+    set(CMAKE_AR /usr/bin/ar)
+    set(CMAKE_RANLIB /usr/bin/ranlib)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_OBJCXX_STANDARD 17)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")


### PR DESCRIPTION
Fixes a macOS linker failure during the final application link step.

The build was failing with:

    ld: archive member '//' not a mach-o file in 'liblexilla.a'

While investigating, I noticed that CMake was using a mixed archive toolchain:

- CMAKE_AR = /usr/bin/ar (Apple/BSD)
- CMAKE_RANLIB = llvm-ranlib (Homebrew LLVM)

The generated liblexilla.a contained entries like "//", "/0", "/19".
These are normal in ar archives, but in this case the linker was misinterpreting them
and treating them as invalid Mach-O objects.

The issue appears to be caused by the mismatch between ar and ranlib.

Fix:
Force both tools to use the Apple toolchain on macOS:

    if(APPLE)
        set(CMAKE_AR /usr/bin/ar)
        set(CMAKE_RANLIB /usr/bin/ranlib)
    endif()

After this change, the project builds and links successfully on macOS (Apple Silicon).