### PR TITLE
Fix language XML lookup on case-sensitive APFS (closes #23)

### DIFF
--- a/src/NppLocalizer.mm
+++ b/src/NppLocalizer.mm
@@ -732,11 +732,26 @@ static const char kOriginalSubmenuTitleKey = 0;
     // Check user directory first (allows overriding bundled files).
     NSString *userDir   = [NppLocalizer userLanguageDirectory];
     NSString *bundleDir = [NppLocalizer bundledLanguageDirectory];
+    NSFileManager *fm   = [NSFileManager defaultManager];
+
+    NSString *targetName = [stem stringByAppendingPathExtension:@"xml"];
 
     for (NSString *dir in @[userDir, bundleDir]) {
+        // Fast path: direct match. Works on case-insensitive volumes
+        // (the macOS default) regardless of how the file is actually cased.
         NSString *path = [[dir stringByAppendingPathComponent:stem]
                           stringByAppendingPathExtension:@"xml"];
-        if ([[NSFileManager defaultManager] fileExistsAtPath:path]) return path;
+        if ([fm fileExistsAtPath:path]) return path;
+
+        // Fallback: case-insensitive directory scan so that files with
+        // mixed-case names (e.g. chineseSimplified.xml) still load when
+        // the volume is case-sensitive APFS — see issue #23.
+        NSArray<NSString *> *entries = [fm contentsOfDirectoryAtPath:dir error:NULL];
+        for (NSString *entry in entries) {
+            if ([entry caseInsensitiveCompare:targetName] == NSOrderedSame) {
+                return [dir stringByAppendingPathComponent:entry];
+            }
+        }
     }
     return nil;
 }


### PR DESCRIPTION
## Summary

On macOS volumes formatted with case-sensitive APFS, language XML files with mixed-case names (e.g. `chineseSimplified.xml`, `taiwaneseMandarin.xml`, `hongKongCantonese.xml`) fail to load because `loadLanguageNamed:` forces the stem to lowercase before searching for the file on disk. The lookup then asks for `chinesesimplified.xml`, which does not exist on a case-sensitive volume.

On the case-insensitive default volume the filesystem hides this mismatch, so the bug is invisible to most users — but it makes the affected languages unusable for anyone running a case-sensitive APFS setup (common on developer machines).

## Fix

`-_xmlPathForStem:` now:

1. **Fast path** — direct `fileExistsAtPath:` check, unchanged. Behaviour on case-insensitive volumes is identical to before, no extra I/O.
2. **Fallback** — if the direct match fails, list the directory and pick the entry that matches the requested name via `caseInsensitiveCompare:`. This resolves the real on-disk casing (e.g. `chineseSimplified.xml`) and returns its actual path.

The fallback is only paid when the fast path misses, so there is no perf regression on healthy lookups.

## Test plan

- [x] Builds clean (Release, Universal arm64+x86_64), no new warnings introduced.
- [x] Verified the affected XML file ships with mixed-case name (`chineseSimplified.xml`) in `resources/localization/`.
- [ ] Manual: switch to Chinese (Simplified) on a case-sensitive APFS volume — language now loads.
- [ ] Manual: switch to Chinese (Simplified) on a case-insensitive volume — still loads (fast path).

Fixes #23