### PR TITLE
Add file status auto-detection and Update silently preferences

### DIFF
--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -950,10 +950,13 @@ static NSUInteger nppLargeFileThreshold(void) {
     // No change if mtime matches what we last recorded.
     if (_lastKnownModDate && [mtime compare:_lastKnownModDate] != NSOrderedDescending) return;
 
+    if (![[NSUserDefaults standardUserDefaults] boolForKey:kPrefFileStatusAutoDetection]) return;
+
     _lastKnownModDate = mtime;
     _externalChangePending = YES;
 
-    if (_monitoringMode) {
+    BOOL updateSilently = [[NSUserDefaults standardUserDefaults] boolForKey:kPrefFileStatusUpdateSilently];
+    if (_monitoringMode || (updateSilently && !_isModified)) {
         NSError *err;
         [self loadFileAtPath:_filePath error:&err];
         _externalChangePending = NO;

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -339,6 +339,8 @@ void writeConfigXML(void) {
     NSInteger inSelThr = [ud integerForKey:kPrefInSelThreshold];
     NSInteger darkMode = [ud integerForKey:kPrefDarkMode];
     BOOL spellCheck    = [ud boolForKey:kPrefSpellCheck];
+    BOOL fileAutoDetect = [ud boolForKey:kPrefFileStatusAutoDetection];
+    BOOL fileUpdateSilent = [ud boolForKey:kPrefFileStatusUpdateSilently];
 
     // Fold style names matching Windows: box, circle, arrow, simple, none
     NSArray *foldNames = @[@"box", @"circle", @"arrow", @"simple", @"none"];
@@ -451,8 +453,10 @@ void writeConfigXML(void) {
     BOOL funcListXML = [ud boolForKey:kPrefFuncListUseXML];
     [xml appendFormat:@"        <GUIConfig name=\"MISC\" muteSounds=\"%@\" "
      @"disableTextDragDrop=\"%@\" spellCheck=\"%@\" "
-     @"panelKeepState=\"%@\" funcListUseXML=\"%@\" />\n",
-     _yn(muteSounds), _yn(disableDrag), _yn(spellCheck), _yn(panelKeep), _yn(funcListXML)];
+     @"panelKeepState=\"%@\" funcListUseXML=\"%@\" "
+     @"fileAutoDetection=\"%@\" fileAutoDetectionUpdate=\"%@\" />\n",
+     _yn(muteSounds), _yn(disableDrag), _yn(spellCheck), _yn(panelKeep), _yn(funcListXML),
+     _yn(fileAutoDetect), _yn(fileUpdateSilent)];
 
     // ScintillaPrimaryView
     [xml appendFormat:@"        <GUIConfig name=\"ScintillaPrimaryView\" "
@@ -641,6 +645,14 @@ void readConfigXML(void) {
                 [ud setBool:_ynBool(v) forKey:kPrefPanelKeepState];
             if ((v = [el attributeForName:@"funcListUseXML"].stringValue))
                 [ud setBool:_ynBool(v) forKey:kPrefFuncListUseXML];
+            if ((v = [el attributeForName:@"fileAutoDetection"].stringValue))
+                [ud setBool:_ynBool(v) forKey:kPrefFileStatusAutoDetection];
+            if ((v = [el attributeForName:@"fileAutoDetectionUpdate"].stringValue))
+                [ud setBool:_ynBool(v) forKey:kPrefFileStatusUpdateSilently];
+            if ((v = [el attributeForName:@"fileStatusAutoDetection"].stringValue))
+                [ud setBool:_ynBool(v) forKey:kPrefFileStatusAutoDetection];
+            if ((v = [el attributeForName:@"fileStatusUpdateSilently"].stringValue))
+                [ud setBool:_ynBool(v) forKey:kPrefFileStatusUpdateSilently];
         }
         else if ([name isEqualToString:@"ScintillaPrimaryView"]) {
             NSString *v;

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -73,6 +73,8 @@ extern NSString *const kPrefLineNumDynWidth;     // BOOL, default YES
 extern NSString *const kPrefInSelThreshold;      // NSInteger, default 1024
 extern NSString *const kPrefFuncListUseXML;      // BOOL, default YES — use XML parsers vs hardcoded regex
 extern NSString *const kPrefToolbarIconScale;    // double, 0.50/0.75/0.90/1.00/1.25/1.50, default 1.0 — restart required
+extern NSString *const kPrefFileStatusAutoDetection; // BOOL, default YES
+extern NSString *const kPrefFileStatusUpdateSilently; // BOOL, default NO; only clean buffers reload silently
 
 // Delimiter pane (issue #42) — two independent features sharing one prefs page,
 // mirroring Windows NPP. (1) "Word character list" extends Scintilla's word

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -63,6 +63,8 @@ NSString *const kPrefLineNumDynWidth     = @"lineNumDynWidth";
 NSString *const kPrefInSelThreshold      = @"inSelThreshold";
 NSString *const kPrefFuncListUseXML      = @"funcListUseXML";
 NSString *const kPrefToolbarIconScale    = @"toolbarIconScale";
+NSString *const kPrefFileStatusAutoDetection = @"fileStatusAutoDetection";
+NSString *const kPrefFileStatusUpdateSilently = @"fileStatusUpdateSilently";
 
 // Delimiter pane (issue #42)
 NSString *const kPrefWordCharsUseDefault = @"wordCharsUseDefault";
@@ -192,6 +194,8 @@ NSString *const kPrefStyleFontSize      = @"styleFontSize";
         kPrefInSelThreshold:       @1024,
         kPrefFuncListUseXML:       @YES,
         kPrefToolbarIconScale:     @1.0,  // 0.50/0.75/0.90/1.00/1.25/1.50 — restart required
+        kPrefFileStatusAutoDetection: @YES,
+        kPrefFileStatusUpdateSilently: @NO,
         kPrefDarkMode:             @0,   // 0=Auto, 1=Light, 2=Dark
         // Performance / Large File Restriction
         kPrefLargeFileEnabled:            @YES,
@@ -296,6 +300,8 @@ NSString *const kPrefStyleFontSize      = @"styleFontSize";
         kPrefAutoBackup:         @YES,
         kPrefBackupInterval:     @60,
         kPrefRememberSession:    @YES,
+        kPrefFileStatusAutoDetection: @YES,
+        kPrefFileStatusUpdateSilently: @NO,
     }];
 }
 
@@ -1631,6 +1637,8 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
         @[[loc translate:@"Remember panel visibility across sessions"], @1204, kPrefPanelKeepState],
         @[[loc translate:@"Use XML-based function list parsers"],      @1205, kPrefFuncListUseXML],
         @[@"Route plugin messages to split view editors",            @1206, kPrefPluginSplitViewRouting],
+        @[[loc translate:@"File Status Auto-Detection"],              @1208, kPrefFileStatusAutoDetection],
+        @[[loc translate:@"Update silently"],                         @1209, kPrefFileStatusUpdateSilently],
     ];
     for (NSArray *def in checks) {
         NSButton *chk = [NSButton checkboxWithTitle:def[0] target:self action:@selector(prefChanged:)];
@@ -1786,6 +1794,8 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
         case 1204: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefPanelKeepState]; break;
         case 1205: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefFuncListUseXML]; break;
         case 1206: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefPluginSplitViewRouting]; break;
+        case 1208: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefFileStatusAutoDetection]; break;
+        case 1209: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefFileStatusUpdateSilently]; break;
         // Performance / Large File Restriction (1400-1407 — 1300s collide with Indentation)
         case 1400: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefLargeFileEnabled]; break;
         case 1401: {


### PR DESCRIPTION
Adds Preferences > MISC. options for File Status Auto-Detection and Update silently.

Behavior:
- File Status Auto-Detection off: external disk changes are ignored.
- Update silently on: clean buffers reload automatically when changed on disk.
- Dirty buffers still prompt before reloading, so unsaved editor changes are not discarded silently.
