### PR TITLE
Make search result chrome readable in light mode

### DIFF
--- a/src/SearchResultsPanel.mm
+++ b/src/SearchResultsPanel.mm
@@ -325,6 +325,8 @@ static sptr_t _srSciColor(NSColor *c) {
 - (void)_applyTheme {
     BOOL dark = [NppThemeManager shared].isDark;
     NPPStyleStore *store = [NPPStyleStore sharedStore];
+    NSAppearance *panelAppearance = [NSAppearance appearanceNamed:
+        dark ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
 
     // Background & foreground from editor theme
     NSColor *bgColor = [store globalBg];
@@ -393,13 +395,19 @@ static sptr_t _srSciColor(NSColor *c) {
     }
 
     // ── Title bar and filter bar background ─────────────────────────────
-    NSColor *panelBg = [NppThemeManager shared].panelBackground;
+    // Use a concrete color here, not a dynamic NSColor bridged to CGColor:
+    // layer colors are resolved at assignment time and can otherwise pick up
+    // the system appearance instead of Nextpad++'s forced light/dark mode.
+    NSColor *panelBg = [NppThemeManager shared].statusBarBackground;
     _titleBar.layer.backgroundColor = panelBg.CGColor;
     _filterBar.layer.backgroundColor = panelBg.CGColor;
+    self.appearance = panelAppearance;
+    _titleBar.appearance = panelAppearance;
+    _filterBar.appearance = panelAppearance;
+    _filterField.appearance = panelAppearance;
 
     // ── Appearance for dark/light disclosure triangles ────────────────────
-    _sci.appearance = [NSAppearance appearanceNamed:
-        dark ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
+    _sci.appearance = panelAppearance;
 
     // Re-colourise if we have content
     if ([_sci message:SCI_GETLENGTH] > 0)


### PR DESCRIPTION
Use mode-stable panel chrome colors and explicit appearance propagation for the search results title bar and in-results filter bar.

Constraint: macOS layer CGColor assignment can resolve dynamic colors against the system appearance instead of the app's forced light/dark mode.

Rejected: Styling the Scintilla result content or filter behavior | request was limited to mode-aware UI chrome colors.

Confidence: high

Scope-risk: narrow

Directive: Keep search result filtering/navigation behavior separate from chrome color updates.

Tested: cmake --build .build --target CMakeFiles/NotepadPlusPlusMac.dir/src/SearchResultsPanel.mm.o; cmake -S . -B .build-release -DCMAKE_BUILD_TYPE=Release; cmake --build .build-release --target NotepadPlusPlusMac before removing local-only build workaround from this commit.

Not-tested: Full release build after pruning the local-only LaunchServices workaround from this branch.