### PR TITLE
Fix #201: Shift+Tab now outdents line content

### DIFF
--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -2308,7 +2308,13 @@ static const struct SciDefaultKeys *sciDefaultKeysFor(int sciID) {
 
     BOOL bsUnindent = [ud boolForKey:kPrefBackspaceUnindent];
     [sci message:SCI_SETBACKSPACEUNINDENTS wParam:bsUnindent ? 1 : 0];
-    [sci message:SCI_SETTABINDENTS wParam:bsUnindent ? 1 : 0];
+    // Tab / Shift+Tab indent/outdent the line, like Notepad++ and most code
+    // editors. This is independent of "Backspace unindents": SCI_SETTABINDENTS
+    // governs whether Shift+Tab dedents line content (otherwise it only moves
+    // the caret). Notepad++ relies on Scintilla's default of tabIndents=true and
+    // never overrides it; we set it explicitly so the behaviour can't regress.
+    // Tying it to bsUnindent (default NO) disabled Shift+Tab outdent (#201).
+    [sci message:SCI_SETTABINDENTS wParam:1];
 
     // Notepad++ "column selection to multi-editing": on Backspace/arrows a
     // column (rectangular) selection is first converted to a stream


### PR DESCRIPTION
## Summary

Fixes #201 — in any language (XML in the report), pressing **Shift+Tab** moved the caret left but did not outdent the line content. Tab worked.

## Root cause

`EditorView.mm` → `applyPreferencesFromDefaults` set `SCI_SETTABINDENTS` to the same value as the *"Backspace unindents"* preference (`kPrefBackspaceUnindent`, default `NO`):

```objc
BOOL bsUnindent = [ud boolForKey:kPrefBackspaceUnindent];
[sci message:SCI_SETBACKSPACEUNINDENTS wParam:bsUnindent ? 1 : 0];
[sci message:SCI_SETTABINDENTS         wParam:bsUnindent ? 1 : 0];   // bug
```

`SCI_SETTABINDENTS` and `SCI_SETBACKSPACEUNINDENTS` are **two independent** Scintilla behaviours:

- `SCI_SETBACKSPACEUNINDENTS` — whether **Backspace** removes a full indent level in leading whitespace.
- `SCI_SETTABINDENTS` — whether **Tab / Shift+Tab** indent/outdent the **line** (vs. just moving the caret).

With `tabIndents` disabled, Scintilla's `Editor::Indent()` (`scintilla/src/Editor.cxx`) only repositions the caret on `SCI_BACKTAB`; the dedent branch is guarded by `column <= indentation && pdoc->tabIndents`. That is exactly the reported symptom.

## Fix

Decouple the two. Keep `SCI_SETBACKSPACEUNINDENTS` tied to the preference; set `SCI_SETTABINDENTS` on unconditionally.

This matches **official Notepad++**, which never calls `SCI_SETTABINDENTS` and relies on Scintilla's `Document` default of `tabIndents = true` (`Document.cxx:171`), while setting `SCI_SETBACKSPACEUNINDENTS` from its own `_backspaceUnindent` setting. We set it explicitly so the behaviour can't regress if the default changes.

## Notes / behaviour change

- Backspace behaviour is unchanged (still governed solely by the preference).
- With the caret in leading whitespace, **Tab** now indents the line rather than inserting a literal tab — this is Scintilla's normal `tabIndents=true` behaviour and matches Notepad++.
- Multi-line selection indent/outdent already used a separate code path and is unaffected.
- This is the only `SCI_SETTABINDENTS` call site in the project.

## Test plan

- Default prefs, caret in a line's leading whitespace → **Shift+Tab outdents** the line (XML and other languages).
- **Tab** still indents.
- Multi-line selection: Tab / Shift+Tab indent / outdent all selected lines.
- **Backspace** does *not* unindent unless *"Backspace unindents"* is enabled in Preferences.
