### PR TITLE
Fix #67: store user data under ~/Library/Application Support/Nextpad++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(APP_SRCS
     src/NppApplication.mm
     src/NppThemeManager.mm
     src/NppCommandLineParams.mm
+    src/NppPaths.mm
     src/ShortcutMapperWindowController.mm
     src/NppLocalizer.mm
     src/NppLangsManager.mm
@@ -144,6 +145,7 @@ set(APP_SRCS
 )
 
 set(APP_HEADERS
+    src/NppPaths.h
     src/NppLocalizer.h
     src/NppLangsManager.h
     src/AppDelegate.h
@@ -259,28 +261,28 @@ add_custom_command(TARGET NotepadPlusPlusMac POST_BUILD
         "$<TARGET_BUNDLE_DIR:NotepadPlusPlusMac>/Contents/Resources/userDefineLangs/"
     COMMENT "Copying pre-installed UDL files into bundle")
 
-# Default shortcuts.xml (copied to ~/.nextpad++/ on first run if missing)
+# Default shortcuts.xml (copied to ~/Library/Application Support/Nextpad++/ on first run if missing)
 add_custom_command(TARGET NotepadPlusPlusMac POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${CMAKE_SOURCE_DIR}/resources/shortcuts.xml"
         "$<TARGET_BUNDLE_DIR:NotepadPlusPlusMac>/Contents/Resources/shortcuts.xml"
     COMMENT "Copying default shortcuts.xml into bundle")
 
-# Default tabContextMenu.xml (copied to ~/.nextpad++/ on first run)
+# Default tabContextMenu.xml (copied to ~/Library/Application Support/Nextpad++/ on first run)
 add_custom_command(TARGET NotepadPlusPlusMac POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${CMAKE_SOURCE_DIR}/resources/tabContextMenu.xml"
         "$<TARGET_BUNDLE_DIR:NotepadPlusPlusMac>/Contents/Resources/tabContextMenu.xml"
     COMMENT "Copying default tabContextMenu.xml into bundle")
 
-# Default contextMenu.xml (copied to ~/.nextpad++/ on first run)
+# Default contextMenu.xml (copied to ~/Library/Application Support/Nextpad++/ on first run)
 add_custom_command(TARGET NotepadPlusPlusMac POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${CMAKE_SOURCE_DIR}/resources/contextMenu.xml"
         "$<TARGET_BUNDLE_DIR:NotepadPlusPlusMac>/Contents/Resources/contextMenu.xml"
     COMMENT "Copying default contextMenu.xml into bundle")
 
-# Default toolbarButtonsConf.xml (copied as _example to ~/.nextpad++/ on first run)
+# Default toolbarButtonsConf.xml (copied as _example to ~/Library/Application Support/Nextpad++/ on first run)
 add_custom_command(TARGET NotepadPlusPlusMac POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${CMAKE_SOURCE_DIR}/resources/toolbarButtonsConf.xml"

--- a/src/AppDelegate.mm
+++ b/src/AppDelegate.mm
@@ -1,4 +1,5 @@
 #import "AppDelegate.h"
+#import "NppPaths.h"
 #import "NppApplication.h"
 #import "MainWindowController.h"
 #import "MenuBuilder.h"
@@ -220,7 +221,7 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
         a.messageText = [[NppLocalizer shared] translate:@"Nextpad++ Loading Time"];
         a.informativeText = msg;
         a.icon = [[NSImage alloc] initWithContentsOfFile:
-            [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins/Config/logo100px.png"]];
+            NppConfigSubpath(@"plugins/Config/logo100px.png")];
         [a runModal];
     }
 
@@ -544,7 +545,7 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
 
 /// Load shortcut overrides from shortcuts.xml <InternalCommands> and apply to live menu items.
 - (void)_loadShortcutOverrides {
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *path = NppConfigSubpath(@"shortcuts.xml");
     NSData *data = [NSData dataWithContentsOfFile:path];
     if (!data) {
         NSLog(@"[Shortcuts] No shortcuts.xml found at %@ — skipping overrides", path);
@@ -707,7 +708,7 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
     if ([panel runModal] != NSModalResponseOK) return;
 
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *themesDir = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/themes"];
+    NSString *themesDir = NppConfigSubpath(@"themes");
     [fm createDirectoryAtPath:themesDir withIntermediateDirectories:YES attributes:nil error:nil];
 
     NSInteger imported = 0;
@@ -760,7 +761,7 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
 
     // Use our logo
     NSImage *logo = [[NSImage alloc] initWithContentsOfFile:
-        [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins/Config/logo100px.png"]];
+        NppConfigSubpath(@"plugins/Config/logo100px.png")];
     if (!logo) {
         // Fallback: try bundle resource
         NSString *logoPath = [[NSBundle mainBundle] pathForResource:@"logo100px" ofType:@"png"

--- a/src/EditorView.h
+++ b/src/EditorView.h
@@ -28,7 +28,7 @@ extern NSNotificationName const EditorViewDidSaveNotification;
 /// non-nil it overrides the "new N" name; ignored once the buffer has a filePath.
 @property (nonatomic, copy, nullable) NSString *customTabName;
 
-/// Path to the auto-backup copy in ~/.nextpad++/backup/ (nil if never backed up).
+/// Path to the auto-backup copy in ~/Library/Application Support/Nextpad++/backup/ (nil if never backed up).
 @property (nonatomic, copy, nullable) NSString *backupFilePath;
 
 /// Restore the untitled index from a saved session (keeps tab name consistent).

--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -1,4 +1,5 @@
 #import "EditorView.h"
+#import "NppPaths.h"
 #import "NppApplication.h"
 #import "NppLangsManager.h"
 #import "UserDefineLangManager.h"
@@ -152,7 +153,7 @@ static NSDictionary<NSString *, NSString *> *extensionLanguageMap() {
             // Markup / Config
             // .md/.markdown intentionally NOT mapped here — markdown is no
             // longer a built-in language; the preinstalled Markdown UDL
-            // (~/.nextpad++/userDefineLangs/markdown._preinstalled.udl.xml)
+            // (~/Library/Application Support/Nextpad++/userDefineLangs/markdown._preinstalled.udl.xml)
             // claims these extensions and is resolved via the UDL fallback
             // in loadFileAtPath:. Mapping them to "markdown" here would
             // shadow that fallback and leave the file plain (issue #130
@@ -2166,7 +2167,7 @@ static const struct SciDefaultKeys *sciDefaultKeysFor(int sciID) {
     return NULL;
 }
 
-// Push the user's Scintilla-command shortcut overrides (from ~/.nextpad++/shortcuts.xml)
+// Push the user's Scintilla-command shortcut overrides (from ~/Library/Application Support/Nextpad++/shortcuts.xml)
 // into this editor's Scintilla keymap. Called once at construction and live on every
 // NPPShortcutsChangedNotification (via MainWindowController). Authoritative-per-command:
 // an overridden command's REAL default key(s) are cleared so the original stops firing,
@@ -2174,7 +2175,7 @@ static const struct SciDefaultKeys *sciDefaultKeysFor(int sciID) {
 // no overrides (and none ever applied) it returns immediately, leaving the stock keymap
 // untouched, so non-customising users see zero change.
 - (void)applyScintillaKeyOverrides {
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *path = NppConfigSubpath(@"shortcuts.xml");
     NSData *data = [NSData dataWithContentsOfFile:path];
 
     // Parse the overrides into a flat list first (sciID, keyCode, keyDef).

--- a/src/FunctionListPanel.mm
+++ b/src/FunctionListPanel.mm
@@ -1,4 +1,5 @@
 #import "FunctionListPanel.h"
+#import "NppPaths.h"
 #import "NppLocalizer.h"
 #import "StyleConfiguratorWindowController.h"
 #import "PreferencesWindowController.h"
@@ -739,9 +740,9 @@ static _FLNode *_findParserNode(_FLNode *root) {
 static _FLNode *_loadParserXML(NSString *lang) {
     NSFileManager *fm = [NSFileManager defaultManager];
 
-    // 1. Check user override: ~/.nextpad++/functionList/<lang>.xml
-    NSString *userPath = [NSHomeDirectory() stringByAppendingPathComponent:
-                          [NSString stringWithFormat:@".nextpad++/functionList/%@.xml", lang]];
+    // 1. Check user override: ~/Library/Application Support/Nextpad++/functionList/<lang>.xml
+    NSString *userPath = NppConfigSubpath(
+                          [NSString stringWithFormat:@"functionList/%@.xml", lang]);
     NSData *data = [fm fileExistsAtPath:userPath] ? [NSData dataWithContentsOfFile:userPath] : nil;
 
     // 2. Fall back to bundled: Resources/functionList/<lang>.xml
@@ -1097,7 +1098,7 @@ static BOOL _isInComment(NSRange range, NSIndexSet *commentRanges) {
     }];
 }
 
-/// Check ~/.nextpad++/functionList/<lang>.xml for a user-defined pattern override.
+/// Check ~/Library/Application Support/Nextpad++/functionList/<lang>.xml for a user-defined pattern override.
 /// Expected format:
 ///   <NotepadPlus><functionList><parser>
 ///     <function mainExpr="regex-with-capture-group-1-for-name" />
@@ -1105,8 +1106,8 @@ static BOOL _isInComment(NSRange range, NSIndexSet *commentRanges) {
 ///   </parser></functionList></NotepadPlus>
 /// Returns nil if no user override exists or the file can't be parsed.
 static NSString *_userFuncPatternForLanguage(NSString *lang, NSString * __autoreleasing *outClassPattern) {
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:
-                      [NSString stringWithFormat:@".nextpad++/functionList/%@.xml", lang.lowercaseString]];
+    NSString *path = NppConfigSubpath(
+                      [NSString stringWithFormat:@"functionList/%@.xml", lang.lowercaseString]);
     NSData *data = [NSData dataWithContentsOfFile:path];
     if (!data) return nil;
 

--- a/src/MainWindowController.h
+++ b/src/MainWindowController.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Load a session file (plist format with tabs array).
 - (void)loadSessionFromPath:(NSString *)path;
 
-/// Restore the last session from ~/.nextpad++/session.plist.
+/// Restore the last session from ~/Library/Application Support/Nextpad++/session.plist.
 - (BOOL)restoreLastSession;
 
 /// Add a plugin-provided toolbar icon.  Called by NppPluginManager when a
@@ -81,10 +81,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/// Write current NSUserDefaults preferences to ~/.nextpad++/config.xml.
+/// Write current NSUserDefaults preferences to ~/Library/Application Support/Nextpad++/config.xml.
 void writeConfigXML(void);
 
-/// Read ~/.nextpad++/config.xml and apply settings to NSUserDefaults.
+/// Read ~/Library/Application Support/Nextpad++/config.xml and apply settings to NSUserDefaults.
 void readConfigXML(void);
 
 /// Regenerate toolbarButtonsConf_example.xml with current plugin entries.

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -1,4 +1,5 @@
 #import "MainWindowController.h"
+#import "NppPaths.h"                 // NppConfigDir()/NppConfigSubpath()
 #import <QuartzCore/QuartzCore.h>   // CAGradientLayer (Tahoe window backdrop)
 #import "TahoeToolbarConfig.h"      // Tahoe toolbar group layout (Liquid Glass)
 #import "AppDelegate.h"
@@ -87,9 +88,11 @@
 
 static NSString *const kWindowFrameKey = @"MainWindowFrame";
 
-// ── ~/.nextpad++ paths (mirrors %APPDATA%\Nextpad++ on Windows) ───────────────
+// ── Config paths (mirrors %APPDATA%\Nextpad++ on Windows) ────────────────────
+// Base dir is ~/Library/Application Support/Nextpad++ (see NppPaths.h); legacy
+// ~/.nextpad++ installs are migrated on first use.
 static NSString *nppConfigDir(void) {
-    return [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++"];
+    return NppConfigDir();
 }
 static NSString *nppBackupDir(void) {
     return [nppConfigDir() stringByAppendingPathComponent:@"backup"];
@@ -300,7 +303,7 @@ static BOOL _ynBool(NSString *s) { return [s.lowercaseString isEqualToString:@"y
 /// Helper: BOOL from "show"/"hide" (default NO)
 static BOOL _shBool(NSString *s) { return [s.lowercaseString isEqualToString:@"show"]; }
 
-/// Write current preferences from NSUserDefaults to ~/.nextpad++/config.xml.
+/// Write current preferences from NSUserDefaults to ~/Library/Application Support/Nextpad++/config.xml.
 void writeConfigXML(void) {
     NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
 
@@ -522,7 +525,7 @@ void writeConfigXML(void) {
     [xml writeToFile:_configXmlPath() atomically:YES encoding:NSUTF8StringEncoding error:nil];
 }
 
-/// Read ~/.nextpad++/config.xml and apply settings to NSUserDefaults.
+/// Read ~/Library/Application Support/Nextpad++/config.xml and apply settings to NSUserDefaults.
 void readConfigXML(void) {
     NSString *path = _configXmlPath();
     NSData *data = [NSData dataWithContentsOfFile:path];
@@ -769,7 +772,7 @@ static void ensureNppDirs(void) {
         }
     }
 
-    // Copy tabContextMenu_example.xml to ~/.nextpad++/ as a template for user customization.
+    // Copy tabContextMenu_example.xml to ~/Library/Application Support/Nextpad++/ as a template for user customization.
     // User renames it to tabContextMenu.xml to activate custom tab context menu.
     NSString *tabCtxExamplePath = [nppConfigDir() stringByAppendingPathComponent:@"tabContextMenu_example.xml"];
     if (![fm fileExistsAtPath:tabCtxExamplePath]) {
@@ -780,7 +783,7 @@ static void ensureNppDirs(void) {
     }
 
     // Copy contextMenu.xml from bundle if user copy doesn't exist.
-    // User edits ~/.nextpad++/contextMenu.xml to customize the editor right-click menu.
+    // User edits ~/Library/Application Support/Nextpad++/contextMenu.xml to customize the editor right-click menu.
     NSString *ctxMenuPath = [nppConfigDir() stringByAppendingPathComponent:@"contextMenu.xml"];
     if (![fm fileExistsAtPath:ctxMenuPath]) {
         NSString *bundleCopy = [[NSBundle mainBundle] pathForResource:@"contextMenu" ofType:@"xml"];
@@ -791,33 +794,33 @@ static void ensureNppDirs(void) {
     }
 
     // Copy langs.model.xml from bundle as langs.xml if user copy doesn't exist.
-    // User edits ~/.nextpad++/langs.xml to customize extensions, keywords, comment delimiters.
+    // User edits ~/Library/Application Support/Nextpad++/langs.xml to customize extensions, keywords, comment delimiters.
     NSString *langsPath = [nppConfigDir() stringByAppendingPathComponent:@"langs.xml"];
     if (![fm fileExistsAtPath:langsPath]) {
         NSString *bundleCopy = [[NSBundle mainBundle] pathForResource:@"langs.model" ofType:@"xml"];
         if (bundleCopy) {
             [fm copyItemAtPath:bundleCopy toPath:langsPath error:nil];
-            NSLog(@"[Langs] Copied langs.model.xml as langs.xml to ~/.nextpad++/");
+            NSLog(@"[Langs] Copied langs.model.xml as langs.xml to %@", nppConfigDir());
         }
     }
 
     // Copy stylers.model.xml from bundle as stylers.xml if user copy doesn't exist.
-    // User edits ~/.nextpad++/stylers.xml to customize the Default theme styles.
+    // User edits ~/Library/Application Support/Nextpad++/stylers.xml to customize the Default theme styles.
     NSString *stylersPath = [nppConfigDir() stringByAppendingPathComponent:@"stylers.xml"];
     if (![fm fileExistsAtPath:stylersPath]) {
         NSString *bundleCopy = [[NSBundle mainBundle] pathForResource:@"stylers.model" ofType:@"xml"];
         if (bundleCopy) {
             [fm copyItemAtPath:bundleCopy toPath:stylersPath error:nil];
-            NSLog(@"[Stylers] Copied stylers.model.xml as stylers.xml to ~/.nextpad++/");
+            NSLog(@"[Stylers] Copied stylers.model.xml as stylers.xml to %@", nppConfigDir());
         }
     }
 
-    // Create ~/.nextpad++/themes/ for user-installed themes (empty on first run).
+    // Create ~/Library/Application Support/Nextpad++/themes/ for user-installed themes (empty on first run).
     NSString *userThemesDir = [nppConfigDir() stringByAppendingPathComponent:@"themes"];
     [fm createDirectoryAtPath:userThemesDir
   withIntermediateDirectories:YES attributes:nil error:nil];
 
-    // Create ~/.nextpad++/functionList/ for user-defined function list parsers.
+    // Create ~/Library/Application Support/Nextpad++/functionList/ for user-defined function list parsers.
     NSString *userFuncListDir = [nppConfigDir() stringByAppendingPathComponent:@"functionList"];
     [fm createDirectoryAtPath:userFuncListDir
   withIntermediateDirectories:YES attributes:nil error:nil];
@@ -831,7 +834,7 @@ static void ensureNppDirs(void) {
         if (bundleCopy) [fm copyItemAtPath:bundleCopy toPath:tbExPath error:nil];
     }
 
-    // Create ~/.nextpad++/toolbarIcons/ for user custom toolbar icon sets.
+    // Create ~/Library/Application Support/Nextpad++/toolbarIcons/ for user custom toolbar icon sets.
     NSString *toolbarIconsDir = [nppConfigDir() stringByAppendingPathComponent:@"toolbarIcons"];
     [fm createDirectoryAtPath:toolbarIconsDir
   withIntermediateDirectories:YES attributes:nil error:nil];
@@ -1235,7 +1238,7 @@ static NSImage *nppToolbarIcon(NSString *fileName) {
     return img;
 }
 
-/// Load a custom toolbar icon from ~/.nextpad++/toolbarIcons/{folderName}/{buttonId}.png
+/// Load a custom toolbar icon from ~/Library/Application Support/Nextpad++/toolbarIcons/{folderName}/{buttonId}.png
 /// Returns nil if not found.
 static NSImage *_customToolbarIcon(NSString *buttonId, NSDictionary *toolbarConfig) {
     // Parse icoFolderName from the config (already parsed, but we need to read it here)
@@ -1661,7 +1664,7 @@ static const CGFloat kTGRadius   = 12.0;  // pill corner radius (rounded, mockup
 
 /// Parse toolbarButtonsConf.xml and return the ordered list of visible buttons.
 /// The XML document order determines toolbar button order (left to right).
-/// Lookup order: ~/.nextpad++/toolbarButtonsConf.xml → bundled default.
+/// Lookup order: ~/Library/Application Support/Nextpad++/toolbarButtonsConf.xml → bundled default.
 static NSDictionary *_parseToolbarConfig(void) {
     NSString *userPath = [nppConfigDir() stringByAppendingPathComponent:@"toolbarButtonsConf.xml"];
     BOOL hasUserConfig = [[NSFileManager defaultManager] fileExistsAtPath:userPath];
@@ -4220,14 +4223,14 @@ static BOOL groupHasTrailingSep(NSString *ident) {
 
 #pragma mark - Session
 
-/// Save session to ~/.nextpad++/session.plist.
-/// Untitled modified tabs are written to ~/.nextpad++/backup/ automatically.
+/// Save session to ~/Library/Application Support/Nextpad++/session.plist.
+/// Untitled modified tabs are written to ~/Library/Application Support/Nextpad++/backup/ automatically.
 - (void)saveSession {
     ensureNppDirs();
     NSString *backupDir = nppBackupDir();
 
     // Persist ALL open tabs so they reopen on next launch.
-    // Modified text files: back up content to ~/.nextpad++/backup/ so unsaved
+    // Modified text files: back up content to ~/Library/Application Support/Nextpad++/backup/ so unsaved
     // changes survive quit.  On next launch they reload from backup and show
     // as modified (Windows NPP behaviour — no save prompt on exit).
     // Binary / large-file tabs: record path only, no backup.
@@ -4362,7 +4365,7 @@ static BOOL groupHasTrailingSep(NSString *ident) {
     }
 }
 
-/// Restore session from ~/.nextpad++/session.plist.
+/// Restore session from ~/Library/Application Support/Nextpad++/session.plist.
 /// Returns YES if at least one tab was restored.
 - (BOOL)restoreLastSession {
     NSDictionary *session = [NSDictionary dictionaryWithContentsOfFile:nppSessionPath()];
@@ -4667,7 +4670,7 @@ static void removeMacroFromShortcutsXML(NSString *name) {
 
 #pragma mark - Auto-save
 
-/// Periodically write all modified editors to ~/.nextpad++/backup/ — never to the original file.
+/// Periodically write all modified editors to ~/Library/Application Support/Nextpad++/backup/ — never to the original file.
 /// Backs up both named and untitled files so unsaved changes survive a crash.
 - (void)autoSaveTick:(NSTimer *)t {
     ensureNppDirs();
@@ -5188,7 +5191,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
         a.messageText = [[NppLocalizer shared] translate:@"No Macro Recorded"];
         a.informativeText = [[NppLocalizer shared] translate:@"Record a macro first using Start Recording."];
         a.icon = [[NSImage alloc] initWithContentsOfFile:
-            [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins/Config/logo100px.png"]];
+            NppConfigSubpath(@"plugins/Config/logo100px.png")];
         [a runModal];
         return;
     }
@@ -7076,7 +7079,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     if ([panel runModal] != NSModalResponseOK) return;
 
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *pluginsDir = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins"];
+    NSString *pluginsDir = NppConfigSubpath(@"plugins");
     [fm createDirectoryAtPath:pluginsDir withIntermediateDirectories:YES attributes:nil error:nil];
 
     NSInteger imported = 0;
@@ -7781,7 +7784,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     // when the active UI language is non-English the title is translated
     // (e.g. "Синтаксисы" / "Мова" / "Langage"), and an
     // isEqualToString:@"Language" check would silently miss and skip the
-    // entire UDL insertion — losing every ~/.nextpad++/userDefineLangs/
+    // entire UDL insertion — losing every ~/Library/Application Support/Nextpad++/userDefineLangs/
     // entry from the menu.
     NSMenuItem *langTop = [[NSApp mainMenu] itemWithTag:kMenuTagLanguage];
     NSMenu *langMenu = langTop.submenu;
@@ -9206,7 +9209,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     else if ([keyTitle isEqualToString:@"Delete"]) keyCode = 46;
 
     // Insert into shortcuts.xml using raw text manipulation (preserves file structure)
-    NSString *shortcutsPath = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *shortcutsPath = NppConfigSubpath(@"shortcuts.xml");
     NSMutableString *xml = [[NSString stringWithContentsOfFile:shortcutsPath
                                                      encoding:NSUTF8StringEncoding error:nil] mutableCopy];
     if (!xml) return;
@@ -9682,7 +9685,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     [a addButtonWithTitle:[loc translate:@"OK"]];
     [a runModal];
 
-    // Open ~/.nextpad++/contextMenu.xml for editing in Nextpad++ itself
+    // Open ~/Library/Application Support/Nextpad++/contextMenu.xml for editing in Nextpad++ itself
     NSString *ctxPath = [nppConfigDir() stringByAppendingPathComponent:@"contextMenu.xml"];
     if ([[NSFileManager defaultManager] fileExistsAtPath:ctxPath]) {
         [self openFileAtPath:ctxPath];
@@ -10389,7 +10392,7 @@ static int64_t _sysctlInt(const char *name) {
     [info appendFormat:@"Bundle ID: %@\n", [[NSBundle mainBundle] bundleIdentifier] ?: @"n/a"];
     [info appendFormat:@"Path: %@\n", [[NSBundle mainBundle] executablePath]];
     [info appendFormat:@"Bundle Path: %@\n", [[NSBundle mainBundle] bundlePath]];
-    [info appendFormat:@"Config Dir: %@/.nextpad++\n", NSHomeDirectory()];
+    [info appendFormat:@"Config Dir: %@\n", nppConfigDir()];
 
     // ── Runtime ──────────────────────────────────────────────────────────
     int translated = 0; size_t tsz = sizeof(translated);
@@ -10418,7 +10421,7 @@ static int64_t _sysctlInt(const char *name) {
     [info appendFormat:@"Auto-Complete Min Chars: %ld\n", (long)[ud integerForKey:@"kPrefAutoCompleteMinChars"]];
 
     // Session info
-    NSString *sessionPath = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/session.plist"];
+    NSString *sessionPath = NppConfigSubpath(@"session.plist");
     BOOL hasSession = [[NSFileManager defaultManager] fileExistsAtPath:sessionPath];
     [info appendFormat:@"Session file: %@\n", hasSession ? @"exists" : @"none"];
     if (hasSession) {
@@ -10522,7 +10525,7 @@ static int64_t _sysctlInt(const char *name) {
 
     // ── Plugins ──────────────────────────────────────────────────────────
     [info appendString:@"\n── Plugins ──\n"];
-    NSString *pluginDir = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins"];
+    NSString *pluginDir = NppConfigSubpath(@"plugins");
     NSFileManager *fm = [NSFileManager defaultManager];
     NSArray<NSString *> *pluginDirs = [fm contentsOfDirectoryAtPath:pluginDir error:nil];
     NSInteger pluginCount = 0;
@@ -10551,7 +10554,7 @@ static int64_t _sysctlInt(const char *name) {
 
     // ── Config Files ─────────────────────────────────────────────────────
     [info appendString:@"\n── Config Files ──\n"];
-    NSString *nppDir = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++"];
+    NSString *nppDir = nppConfigDir();
     NSArray *configFiles = @[@"session.plist", @"macros.plist", @"plugins/Config/URLPlugin.json"];
     for (NSString *relPath in configFiles) {
         NSString *fullPath = [nppDir stringByAppendingPathComponent:relPath];
@@ -10584,7 +10587,7 @@ static int64_t _sysctlInt(const char *name) {
     NSAlert *a = [[NSAlert alloc] init];
     a.messageText = [[NppLocalizer shared] translate:@"Debug Info"];
     a.icon = [[NSImage alloc] initWithContentsOfFile:
-        [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins/Config/logo100px.png"]];
+        NppConfigSubpath(@"plugins/Config/logo100px.png")];
     [a addButtonWithTitle:[[NppLocalizer shared] translate:@"Copy"]];
     [a addButtonWithTitle:[[NppLocalizer shared] translate:@"OK"]];
 
@@ -10627,7 +10630,7 @@ static int64_t _sysctlInt(const char *name) {
 
 - (BOOL)windowShouldClose:(NSWindow *)sender {
     // Windows NPP behaviour: no save prompts on quit.
-    // Back up all modified editors to ~/.nextpad++/backup/ and save session.
+    // Back up all modified editors to ~/Library/Application Support/Nextpad++/backup/ and save session.
     // On next launch, modified files reload from backup and show as unsaved.
     //
     // Issue #87 — gate the session save on the new "Remember current session

--- a/src/NppLangsManager.h
+++ b/src/NppLangsManager.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)shared;
 
-/// Load from ~/.nextpad++/langs.xml (or bundle fallback).
+/// Load from ~/Library/Application Support/Nextpad++/langs.xml (or bundle fallback).
 - (void)loadLangs;
 
 /// Look up language definition by name (e.g. "cpp", "python").

--- a/src/NppLangsManager.mm
+++ b/src/NppLangsManager.mm
@@ -1,4 +1,5 @@
 #import "NppLangsManager.h"
+#import "NppPaths.h"
 
 // ── NppLangDef ───────────────────────────────────────────────────────────────
 
@@ -51,7 +52,7 @@
     [_extMap removeAllObjects];
 
     // Try user langs.xml first, fall back to bundled langs.model.xml
-    NSString *userPath = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/langs.xml"];
+    NSString *userPath = NppConfigSubpath(@"langs.xml");
     NSData *data = [[NSFileManager defaultManager] fileExistsAtPath:userPath]
                    ? [NSData dataWithContentsOfFile:userPath] : nil;
     if (!data) {

--- a/src/NppPaths.h
+++ b/src/NppPaths.h
@@ -1,0 +1,29 @@
+//  NppPaths.h
+//  Centralised resolver for the Nextpad++ user-data directory.
+//
+//  Nextpad++ keeps user configuration, plugins, backups, session state and the
+//  like under a single base directory. Historically that was the hidden
+//  ~/.nextpad++ folder (a straight port of %APPDATA%\Nextpad++ on Windows).
+//  macOS applications are expected to store this kind of data under
+//  ~/Library/Application Support/<AppName> instead (see GitHub issue #67), so
+//  that is the base directory used now. NppConfigDir() migrates an existing
+//  ~/.nextpad++ folder to the new location once, on first use.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Base user-data directory: ~/Library/Application Support/Nextpad++.
+/// The directory is created if it does not exist. The first call after upgrading
+/// from a build that used ~/.nextpad++ migrates that legacy folder here.
+FOUNDATION_EXPORT NSString *NppConfigDir(void);
+
+/// Convenience: NppConfigDir() joined with a relative subpath, e.g.
+/// NppConfigSubpath(@"plugins") or NppConfigSubpath(@"shortcuts.xml").
+FOUNDATION_EXPORT NSString *NppConfigSubpath(NSString *relativePath);
+
+/// The legacy ~/.nextpad++ directory. Exposed for migration/diagnostics only;
+/// normal code should use NppConfigDir()/NppConfigSubpath().
+FOUNDATION_EXPORT NSString *NppLegacyConfigDir(void);
+
+NS_ASSUME_NONNULL_END

--- a/src/NppPaths.mm
+++ b/src/NppPaths.mm
@@ -1,0 +1,105 @@
+//  NppPaths.mm
+//  See NppPaths.h.
+
+#import "NppPaths.h"
+
+NSString *NppLegacyConfigDir(void) {
+    return [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++"];
+}
+
+static NSString *NppComputeConfigDir(void) {
+    NSString *appSupport = [NSSearchPathForDirectoriesInDomains(
+        NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject];
+    if (appSupport.length == 0) {
+        // Should not happen on macOS, but keep a sane fallback.
+        appSupport = [NSHomeDirectory()
+            stringByAppendingPathComponent:@"Library/Application Support"];
+    }
+    return [appSupport stringByAppendingPathComponent:@"Nextpad++"];
+}
+
+// Recursively move everything under `src` into `dst`, NEVER overwriting an
+// existing destination. Returns YES iff `src` ends up fully drained (so the
+// caller may remove it).
+//   - No collision: a plain move (atomic same-volume rename) handles a file or a
+//     whole subtree at once; falls back to copy+delete across volumes.
+//   - Both sides are directories: merge child-by-child with the same rule.
+//   - File-vs-existing collision: the destination (newer) copy wins and the
+//     legacy item is left in place — nothing is lost.
+static BOOL NppMergeMove(NSFileManager *fm, NSString *src, NSString *dst) {
+    BOOL srcIsDir = NO;
+    if (![fm fileExistsAtPath:src isDirectory:&srcIsDir]) return YES;  // vanished
+
+    if (![fm fileExistsAtPath:dst]) {
+        NSError *moveErr = nil;
+        if ([fm moveItemAtPath:src toPath:dst error:&moveErr]) return YES;
+        NSError *copyErr = nil;
+        if ([fm copyItemAtPath:src toPath:dst error:&copyErr]) {
+            [fm removeItemAtPath:src error:NULL];
+            return YES;
+        }
+        NSLog(@"[Config] Failed to migrate %@ (move: %@; copy: %@)", src, moveErr, copyErr);
+        return NO;
+    }
+
+    BOOL dstIsDir = NO;
+    [fm fileExistsAtPath:dst isDirectory:&dstIsDir];
+    if (!srcIsDir || !dstIsDir) {
+        NSLog(@"[Config] Keeping %@; legacy copy left at %@", dst, src);
+        return NO;
+    }
+
+    BOOL drained = YES;
+    for (NSString *name in [fm contentsOfDirectoryAtPath:src error:NULL]) {
+        if (!NppMergeMove(fm, [src stringByAppendingPathComponent:name],
+                              [dst stringByAppendingPathComponent:name]))
+            drained = NO;
+    }
+    if (drained) [fm removeItemAtPath:src error:NULL];
+    return drained;
+}
+
+// One-time migration of a legacy ~/.nextpad++ tree into the new base dir.
+//
+// The new base dir may ALREADY EXIST on a first upgrade — e.g. NppLocalizer
+// eagerly creates ~/Library/Application Support/Nextpad++/localization. So
+// "new dir exists" is NOT a valid "already migrated" sentinel; treating it as
+// one would strand the user's real config/session/plugins in ~/.nextpad++.
+// Instead we recursively merge the legacy tree into the new one, never
+// clobbering anything already present, and remove the legacy dir only once it
+// is fully drained (so a partial failure leaves un-migrated items in place).
+static void NppMigrateLegacyIfNeeded(NSString *newDir) {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *legacy = NppLegacyConfigDir();
+
+    BOOL legacyIsDir = NO;
+    BOOL hasLegacy = [fm fileExistsAtPath:legacy isDirectory:&legacyIsDir] && legacyIsDir;
+    if (!hasLegacy) return;                    // nothing to migrate (fresh install)
+
+    [fm createDirectoryAtPath:newDir withIntermediateDirectories:YES
+                   attributes:nil error:NULL];
+
+    if (NppMergeMove(fm, legacy, newDir))
+        NSLog(@"[Config] Migrated legacy %@ into %@", legacy, newDir);
+    else
+        NSLog(@"[Config] Partially migrated %@ into %@ (some items kept in place)",
+              legacy, newDir);
+}
+
+NSString *NppConfigDir(void) {
+    static NSString *dir;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        dir = NppComputeConfigDir();
+        NppMigrateLegacyIfNeeded(dir);
+        [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:NULL];
+    });
+    return dir;
+}
+
+NSString *NppConfigSubpath(NSString *relativePath) {
+    return [NppConfigDir() stringByAppendingPathComponent:relativePath];
+}

--- a/src/NppPluginManager.h
+++ b/src/NppPluginManager.h
@@ -11,7 +11,7 @@ extern NSNotificationName const NppPluginsDidLoadNotification;
 /// Manages the lifecycle of Nextpad++ dylib plugins on macOS.
 ///
 /// Responsibilities:
-///   - Discover and load .dylib plugins from ~/.nextpad++/plugins/
+///   - Discover and load .dylib plugins from ~/Library/Application Support/Nextpad++/plugins/
 ///   - Resolve the 5 mandatory C exports (setInfo, getName, etc.)
 ///   - Build NppData with opaque handles and a sendMessage function pointer
 ///   - Dispatch NPPM_* messages from plugins to the host

--- a/src/NppPluginManager.mm
+++ b/src/NppPluginManager.mm
@@ -1,4 +1,5 @@
 #import "NppPluginManager.h"
+#import "NppPaths.h"
 #import "MainWindowController.h"
 #import "MenuBuilder.h"        // kMenuTagPlugins
 #import "PreferencesWindowController.h"
@@ -190,7 +191,7 @@ static const uintptr_t kHandleScintillaSub   = 0x5343490B;  // "SCI\v"
 // ── Plugin directory ────────────────────────────────────────────────────
 
 static NSString *pluginBaseDir(void) {
-    return [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins"];
+    return NppConfigSubpath(@"plugins");
 }
 
 // All editors across primary + secondary (V + H split) tab managers, in
@@ -1083,7 +1084,7 @@ static intptr_t _npp_run_on_main(intptr_t (^block)(void)) {
         case NPPM_GETNPPSETTINGSDIRPATH: {
             char *buf = (char *)lParam;
             if (buf) {
-                NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++"];
+                NSString *path = NppConfigDir();
                 strlcpy(buf, path.UTF8String, 1024);
                 return (intptr_t)strlen(buf);
             }

--- a/src/NppTabBar.mm
+++ b/src/NppTabBar.mm
@@ -1,4 +1,5 @@
 #import "NppTabBar.h"
+#import "NppPaths.h"
 #import "NppThemeManager.h"
 #import "PreferencesWindowController.h"
 #import "NppLocalizer.h"   // match tab-menu items by normalized English title (locale-proof)
@@ -1252,7 +1253,7 @@ static NSMenu *_buildTabContextMenuFromXML(NSString *xmlPath) {
 
 - (NSMenu *)buildTabContextMenu {
     // Try user-customized tabContextMenu.xml first
-    NSString *configDir = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++"];
+    NSString *configDir = NppConfigDir();
     NSString *customPath = [configDir stringByAppendingPathComponent:@"tabContextMenu.xml"];
     NSMenu *menu = _buildTabContextMenuFromXML(customPath);
     if (menu) return menu;

--- a/src/PluginsAdminWindowController.mm
+++ b/src/PluginsAdminWindowController.mm
@@ -1,4 +1,5 @@
 #import "PluginsAdminWindowController.h"
+#import "NppPaths.h"
 #import "NppPluginManager.h"
 #import "NppLocalizer.h"
 #import <CommonCrypto/CommonDigest.h>
@@ -31,7 +32,7 @@
 @property (nonatomic, copy) NSString *macNppMinVersion;   // minimum host version
 
 // Runtime-only state populated by the Updates-tab scanner.
-@property (nonatomic, copy) NSString *installedDylibSHA;  // sha256(~/.nextpad++/plugins/<folder>/<folder>.dylib)
+@property (nonatomic, copy) NSString *installedDylibSHA;  // sha256(~/Library/Application Support/Nextpad++/plugins/<folder>/<folder>.dylib)
 @property (nonatomic, copy) NSString *installedDylibDate; // YYYY-MM-DD of that file's mtime
 @end
 
@@ -575,8 +576,7 @@ static NSString *const kPluginListVersion = @"0.2.0";
             catalogByFolder[pe.folderName] = pe;
     }
 
-    NSString *pluginsDir = [NSHomeDirectory()
-        stringByAppendingPathComponent:@".nextpad++/plugins"];
+    NSString *pluginsDir = NppConfigSubpath(@"plugins");
 
     for (NppPluginEntry *ip in _installed) {
         NppPluginEntry *c = catalogByFolder[ip.folderName];
@@ -609,7 +609,7 @@ static NSString *const kPluginListVersion = @"0.2.0";
 
 - (void)scanInstalledPlugins {
     [_installed removeAllObjects];
-    NSString *pluginsDir = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/plugins"];
+    NSString *pluginsDir = NppConfigSubpath(@"plugins");
     NSFileManager *fm = [NSFileManager defaultManager];
     NSArray *subdirs = [fm contentsOfDirectoryAtPath:pluginsDir error:nil];
 
@@ -711,8 +711,7 @@ static NSInteger compareSemver(NSString *a, NSString *b) {
 // one hash and one stat per installed dylib. Called when the user opens
 // the Updates tab; re-run on each open so we pick up any manual edits.
 - (void)refreshInstalledDylibFingerprints {
-    NSString *pluginsDir = [NSHomeDirectory()
-        stringByAppendingPathComponent:@".nextpad++/plugins"];
+    NSString *pluginsDir = NppConfigSubpath(@"plugins");
     NSFileManager *fm = [NSFileManager defaultManager];
 
     // Build a folder-name → full-dylib-path map from _installed (which
@@ -798,7 +797,7 @@ static NSInteger compareSemver(NSString *a, NSString *b) {
             _actionButton.title = [loc translate:@"Update"];
             _actionButton.hidden = NO;
             // Re-scan on every Updates-tab open — cheap, and keeps us
-            // honest against manual edits to ~/.nextpad++/plugins/.
+            // honest against manual edits to ~/Library/Application Support/Nextpad++/plugins/.
             [self refreshInstalledDylibFingerprints];
             [_filteredList addObjectsFromArray:[self updateCandidates]];
             break;
@@ -1054,7 +1053,7 @@ static NSInteger compareSemver(NSString *a, NSString *b) {
         @"%@\n\n%@\n\n%@\n\n%@",
         [loc translate:@"Update the following plugins?"],
         [names componentsJoinedByString:@"\n"],
-        [loc translate:@"Current versions are backed up to ~/.nextpad++/plugin-backups/ before being replaced."],
+        [loc translate:@"Current versions are backed up to ~/Library/Application Support/Nextpad++/plugin-backups/ before being replaced."],
         [loc translate:@"Restart the application for changes to take effect."]];
     [confirm addButtonWithTitle:[loc translate:@"Update"]];
     [confirm addButtonWithTitle:[loc translate:@"Cancel"]];
@@ -1082,15 +1081,14 @@ static NSInteger compareSemver(NSString *a, NSString *b) {
     }];
 }
 
-// Zip the plugin folder to ~/.nextpad++/plugin-backups/<folder>_<ts>.zip
+// Zip the plugin folder to ~/Library/Application Support/Nextpad++/plugin-backups/<folder>_<ts>.zip
 // via ditto -c -k --keepParent, then remove the folder. Returns YES iff
 // both steps succeeded so the caller knows it's safe to let the
 // extraction step overwrite.
 - (BOOL)backupAndDeletePluginFolder:(NppPluginEntry *)pe {
-    NSString *home       = NSHomeDirectory();
-    NSString *pluginDir  = [[home stringByAppendingPathComponent:@".nextpad++/plugins"]
+    NSString *pluginDir  = [NppConfigSubpath(@"plugins")
         stringByAppendingPathComponent:pe.folderName];
-    NSString *backupDir  = [home stringByAppendingPathComponent:@".nextpad++/plugin-backups"];
+    NSString *backupDir  = NppConfigSubpath(@"plugin-backups");
     NSFileManager *fm    = [NSFileManager defaultManager];
 
     // If there's nothing on disk, there's nothing to back up or remove —
@@ -1102,7 +1100,7 @@ static NSInteger compareSemver(NSString *a, NSString *b) {
                         attributes:nil error:&err]) {
         NSLog(@"[PluginsAdmin] Backup dir create failed: %@", err);
         [self showInstallError:pe.displayName
-                       detail:@"Could not create ~/.nextpad++/plugin-backups/. Update skipped — existing plugin folder is untouched."];
+                       detail:@"Could not create the plugin-backups folder. Update skipped — existing plugin folder is untouched."];
         return NO;
     }
 
@@ -1213,9 +1211,8 @@ static NSInteger compareSemver(NSString *a, NSString *b) {
                     }
                 }
 
-                // Extract ZIP to ~/.nextpad++/plugins/
-                NSString *pluginsDir = [NSHomeDirectory()
-                    stringByAppendingPathComponent:@".nextpad++/plugins"];
+                // Extract ZIP to ~/Library/Application Support/Nextpad++/plugins/
+                NSString *pluginsDir = NppConfigSubpath(@"plugins");
                 NSFileManager *fm = [NSFileManager defaultManager];
                 [fm createDirectoryAtPath:pluginsDir withIntermediateDirectories:YES
                                attributes:nil error:nil];
@@ -1299,8 +1296,7 @@ static NSInteger compareSemver(NSString *a, NSString *b) {
     [confirm beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse resp) {
         if (resp != NSAlertFirstButtonReturn) return;
 
-        NSString *pluginsDir = [NSHomeDirectory()
-            stringByAppendingPathComponent:@".nextpad++/plugins"];
+        NSString *pluginsDir = NppConfigSubpath(@"plugins");
         NSFileManager *fm = [NSFileManager defaultManager];
 
         for (NSString *name in self->_checkedPlugins) {

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -1,4 +1,5 @@
 #import "PreferencesWindowController.h"
+#import "NppPaths.h"
 #import "NppLocalizer.h"
 #import "NppLangsManager.h"
 #import "NppThemeManager.h"
@@ -1801,7 +1802,7 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
     y -= 20;
 
     NSTextField *backupPath = [NSTextField labelWithString:
-        [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/backup/"]];
+        NppConfigSubpath(@"backup")];
     backupPath.frame = NSMakeRect(20, y, 400, 20);
     backupPath.font = [NSFont monospacedSystemFontOfSize:11 weight:NSFontWeightRegular];
     [v addSubview:backupPath];

--- a/src/ShortcutMapperWindowController.mm
+++ b/src/ShortcutMapperWindowController.mm
@@ -1,4 +1,5 @@
 #import "ShortcutMapperWindowController.h"
+#import "NppPaths.h"
 #import "AppDelegate.h"
 #import "MainWindowController.h"
 #import "MenuBuilder.h"          // kMenuTagPlugins
@@ -385,7 +386,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     }
     // Mark entries that have overrides in shortcuts.xml and restore their shortcuts
     // from the XML (macOS may silently clear duplicate keyEquivalents on live menu items)
-    NSString *scPath = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *scPath = NppConfigSubpath(@"shortcuts.xml");
     NSData *scData = [NSData dataWithContentsOfFile:scPath];
     if (scData) {
         NSXMLDocument *scDoc = [[NSXMLDocument alloc] initWithData:scData options:0 error:nil];
@@ -498,7 +499,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
 
 - (void)_loadMacroEntries {
     _macroEntries = [NSMutableArray array];
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *path = NppConfigSubpath(@"shortcuts.xml");
     NSData *data = [NSData dataWithContentsOfFile:path];
     if (!data) return;
     NSXMLDocument *doc = [[NSXMLDocument alloc] initWithData:data options:0 error:nil];
@@ -525,7 +526,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     _runCmdEntries = [NSMutableArray array];
 
     // Load from shortcuts.xml <UserDefinedCommands> only (matches Windows behavior)
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *path = NppConfigSubpath(@"shortcuts.xml");
     NSData *data = [NSData dataWithContentsOfFile:path];
 
     // If no UserDefinedCommands exist in shortcuts.xml, create defaults
@@ -552,7 +553,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
         }
     }
 
-    // Default entries come from the bundled shortcuts.xml (copied to ~/.nextpad++/ on first run)
+    // Default entries come from the bundled shortcuts.xml (copied to ~/Library/Application Support/Nextpad++/ on first run)
     NSLog(@"[ShortcutMapper] Run commands: %lu entries", (unsigned long)_runCmdEntries.count);
 }
 
@@ -709,7 +710,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
         {"SCI_ROTATESELECTION",      2606, NO,  NO,  NO,  0},
     };
     // Read existing overrides from shortcuts.xml
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *path = NppConfigSubpath(@"shortcuts.xml");
     NSData *xmlData = [NSData dataWithContentsOfFile:path];
     NSXMLDocument *xmlDoc = xmlData ? [[NSXMLDocument alloc] initWithData:xmlData options:0 error:nil] : nil;
     NSArray *xmlScintKeys = xmlDoc ? [xmlDoc nodesForXPath:@"//ScintillaKeys/ScintKey" error:nil] : @[];
@@ -1288,7 +1289,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
 }
 
 - (void)_saveToShortcutsXML {
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/shortcuts.xml"];
+    NSString *path = NppConfigSubpath(@"shortcuts.xml");
 
     // Read existing shortcuts.xml — modify in-place to preserve comments and structure
     NSData *existingData = [NSData dataWithContentsOfFile:path];

--- a/src/StyleConfiguratorWindowController.mm
+++ b/src/StyleConfiguratorWindowController.mm
@@ -1,4 +1,5 @@
 #import "StyleConfiguratorWindowController.h"
+#import "NppPaths.h"
 #import "PreferencesWindowController.h"
 #import "NppLocalizer.h"
 
@@ -151,8 +152,8 @@ static NSString *modelLexerID(NSString *themeID) {
 }
 
 - (NSMutableArray<NPPLexer *> *)_parseDefaultXML {
-    // Read from ~/.nextpad++/stylers.xml first (user-editable), fall back to bundle model.
-    NSString *userStylers = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/stylers.xml"];
+    // Read from ~/Library/Application Support/Nextpad++/stylers.xml first (user-editable), fall back to bundle model.
+    NSString *userStylers = NppConfigSubpath(@"stylers.xml");
     NSURL *url = nil;
     if ([[NSFileManager defaultManager] fileExistsAtPath:userStylers]) {
         url = [NSURL fileURLWithPath:userStylers];
@@ -190,7 +191,7 @@ static NSString *modelLexerID(NSString *themeID) {
         return result; // "Default (stylers.xml)" = pure model defaults
     }
 
-    // Find theme XML: check user ~/.nextpad++/themes/ first, then bundle
+    // Find theme XML: check user ~/Library/Application Support/Nextpad++/themes/ first, then bundle
     NSURL *themeURL = nil;
     NSString *userPath = [_userThemesDir() stringByAppendingPathComponent:
                           [themeName stringByAppendingPathExtension:@"xml"]];
@@ -243,9 +244,9 @@ static NSString *modelLexerID(NSString *themeID) {
 
 // ── Available themes ──────────────────────────────────────────────────────────
 
-/// Return path to ~/.nextpad++/themes/ (user-installed themes directory).
+/// Return path to ~/Library/Application Support/Nextpad++/themes/ (user-installed themes directory).
 static NSString *_userThemesDir(void) {
-    return [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/themes"];
+    return NppConfigSubpath(@"themes");
 }
 
 - (NSArray<NSString *> *)availableThemeNames {
@@ -254,7 +255,7 @@ static NSString *_userThemesDir(void) {
 
     NSMutableSet<NSString *> *seen = [NSMutableSet new]; // deduplicate by name
 
-    // Scan user themes first (~/.nextpad++/themes/) — user themes override bundled
+    // Scan user themes first (~/Library/Application Support/Nextpad++/themes/) — user themes override bundled
     NSString *userDir = _userThemesDir();
     NSArray<NSString *> *userFiles = [[NSFileManager defaultManager]
         contentsOfDirectoryAtPath:userDir error:nil];
@@ -450,7 +451,7 @@ static NSString *_userThemesDir(void) {
     // Determine target XML file
     NSString *xmlPath;
     if ([themeName isEqualToString:kDefaultThemeName] || !themeName.length) {
-        xmlPath = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/stylers.xml"];
+        xmlPath = NppConfigSubpath(@"stylers.xml");
     } else {
         // User themes dir first; if not there, copy from bundle
         NSString *userPath = [_userThemesDir() stringByAppendingPathComponent:

--- a/src/TahoeToolbarConfig.h
+++ b/src/TahoeToolbarConfig.h
@@ -3,7 +3,7 @@
 //  Nextpad++ (macOS) — Liquid Glass / Tahoe profile
 //
 //  Persistence + model for the Tahoe toolbar's group layout, stored in
-//  ~/.nextpad++/toolbarButtonsTahoeConf.xml. This is a SEPARATE file from the
+//  ~/Library/Application Support/Nextpad++/toolbarButtonsTahoeConf.xml. This is a SEPARATE file from the
 //  Classic toolbarButtonsConf.xml on purpose (see RFC §5.2.6): the Classic file
 //  is rename-to-activate, whereas the Tahoe toolbar must be active whenever the
 //  user is in the Tahoe appearance — driven by NPPAppearanceStyle, not by whether
@@ -36,7 +36,7 @@ extern NSString *const NPPTahoeToolbarConfigChanged;
 
 @interface TahoeToolbarConfig : NSObject
 
-/// ~/.nextpad++/toolbarButtonsTahoeConf.xml
+/// ~/Library/Application Support/Nextpad++/toolbarButtonsTahoeConf.xml
 + (NSString *)filePath;
 
 /// Parse the file into the model. Returns nil if the file does not exist (the

--- a/src/TahoeToolbarConfig.mm
+++ b/src/TahoeToolbarConfig.mm
@@ -6,13 +6,14 @@
 //
 
 #import "TahoeToolbarConfig.h"
+#import "NppPaths.h"
 
 NSString *const NPPTahoeToolbarConfigChanged = @"NPPTahoeToolbarConfigChanged";
 
 // Mirrors nppConfigDir() in MainWindowController.mm (kept local to avoid a header
-// dependency): ~/.nextpad++.
+// dependency): ~/Library/Application Support/Nextpad++.
 static NSString *_tahoeConfigDir(void) {
-    return [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++"];
+    return NppConfigDir();
 }
 
 static NSString *const kSchemaHeader =

--- a/src/UserDefineLangManager.h
+++ b/src/UserDefineLangManager.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Delete a UDL (removes from user directory).
 - (BOOL)deleteLanguage:(UserDefinedLang *)lang;
 
-/// Path to the user UDL directory (~/.nextpad++/userDefineLangs/).
+/// Path to the user UDL directory (~/Library/Application Support/Nextpad++/userDefineLangs/).
 + (NSString *)userUDLDirectory;
 
 /// Path to the bundled UDL directory (inside app bundle).

--- a/src/UserDefineLangManager.mm
+++ b/src/UserDefineLangManager.mm
@@ -1,4 +1,5 @@
 #import "UserDefineLangManager.h"
+#import "NppPaths.h"
 #import "NppThemeManager.h"
 #import "ScintillaView.h"
 #import "Scintilla.h"
@@ -50,8 +51,7 @@ extern "C" Scintilla::ILexer5 *CreateLexer(const char *name);
 #pragma mark - Directory paths
 
 + (NSString *)userUDLDirectory {
-    NSString *home = NSHomeDirectory();
-    NSString *dir = [home stringByAppendingPathComponent:@".nextpad++/userDefineLangs"];
+    NSString *dir = NppConfigSubpath(@"userDefineLangs");
     [[NSFileManager defaultManager] createDirectoryAtPath:dir
                               withIntermediateDirectories:YES attributes:nil error:nil];
     return dir;
@@ -73,7 +73,7 @@ extern "C" Scintilla::ILexer5 *CreateLexer(const char *name);
     [self _loadFromDirectory:[UserDefineLangManager userUDLDirectory]];
 
     // Also check for the legacy single-file container (userDefineLang.xml)
-    NSString *legacyPath = [NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/userDefineLang.xml"];
+    NSString *legacyPath = NppConfigSubpath(@"userDefineLang.xml");
     if ([[NSFileManager defaultManager] fileExistsAtPath:legacyPath]) {
         [self _loadFromContainerFile:legacyPath];
     }

--- a/test_plugins/test_plugins.mm
+++ b/test_plugins/test_plugins.mm
@@ -1,7 +1,7 @@
 /*
  * test_plugins.mm — Plugin load-test harness for Nextpad++ macOS
  *
- * Scans ~/.nextpad++/plugins/ and verifies each plugin:
+ * Scans ~/Library/Application Support/Nextpad++/plugins/ and verifies each plugin:
  *   1. dylib loads (dlopen)
  *   2. All 5 required exports resolve (dlsym)
  *   3. getName() returns a valid string
@@ -187,7 +187,7 @@ int main(int argc, const char *argv[]) {
             pluginsDir = [NSString stringWithUTF8String:argv[1]];
         } else {
             pluginsDir = [NSHomeDirectory() stringByAppendingPathComponent:
-                          @".nextpad++/plugins"];
+                          @"Library/Application Support/Nextpad++/plugins"];
         }
 
         printf("\n  Plugin Load-Test Harness\n");


### PR DESCRIPTION
## Summary

Fixes #67. Nextpad++ stored its user data (config, session, plugins, backups, themes, UDLs, etc.) in the hidden `~/.nextpad++` folder — a port of `%APPDATA%\Nextpad++` from Windows. On macOS this kind of data belongs under `~/Library/Application Support/<AppName>`; dotfolders in `$HOME` are reserved for low-level unix tooling.

This moves the base directory to **`~/Library/Application Support/Nextpad++`**, with a one-time migration of existing installs.

## What changed

- **New `src/NppPaths.{h,mm}`** — a single resolver:
  - `NppConfigDir()` → `~/Library/Application Support/Nextpad++` (created if missing).
  - `NppConfigSubpath(@"…")` → a child of it.
- **Routed every call site through it.** Previously ~30 places independently built `[NSHomeDirectory() stringByAppendingPathComponent:@".nextpad++/…"]` across ~15 files. `MainWindowController`'s existing `nppConfigDir()` helper (used by ~30 internal callers) now just returns `NppConfigDir()`; the standalone literals elsewhere now call the shared helper. Stale path strings in comments and user-facing dialogs were updated too.
- This is the same base path `NppLocalizer` already used for `…/Nextpad++/localization`, so the layout is now consistent.

## Migration

On first launch after upgrade, a legacy `~/.nextpad++` is merged into the new location. Key detail: the new base dir **can already exist** (localization is created eagerly), so "new dir exists" is *not* treated as "already migrated" — that would strand the user's real config. Instead it does a **recursive merge that never overwrites** anything already present (same-volume moves are atomic renames, with a copy+delete fallback across volumes), and removes the legacy folder only once it is fully drained. A file collision keeps the newer copy and leaves the legacy file in place — nothing is lost.

## Testing

- Full `cmake` build links and code-signs cleanly.
- Migration verified with a sandboxed unit test (temp dirs only) covering: no-collision file/subtree moves, directory merges into a pre-existing dir (`themes/`, `localization/`), file-collision keep-newer behavior, and partial-drain (legacy retained only for the colliding item). All assertions pass.

## Notes

- No compatibility symlink is left in `$HOME`, per the spirit of the issue (keep the home folder clean). Plugins receive the new path through the existing host API (`NPPM_GETNPPSETTINGSDIRPATH` / plugin dir query), so they follow automatically.
