### PR TITLE
Fix indentation preferences not persisting on close

### DIFF
--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -1309,6 +1309,15 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
 
     [v addSubview:optBox];
 
+    // [Default] is selected initially — hide "Use default value" checkbox and
+    // enable controls. The table selection delegate may not fire during page
+    // construction because the view isn't yet in a window.
+    defaultChk.hidden = YES;
+    sizeField.enabled = YES;
+    tabRadio.enabled = YES;
+    spaceRadio.enabled = YES;
+    bsChk.enabled = YES;
+
     // ── Auto-indent radio group (right of Indent Settings) ──
     NSBox *autoBox = [[NSBox alloc] initWithFrame:NSMakeRect(215, y - 90, 160, 100)];
     autoBox.title = [loc translate:@"Auto-indent"];
@@ -2487,6 +2496,7 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
 
 - (void)closePrefs:(id)sender {
     [self _saveClickableSchemes];
+    [self.window makeFirstResponder:nil]; // commit any in-progress text field edits
     [self.window orderOut:nil];
 }
 


### PR DESCRIPTION
## Problem

When editing the indent size on the **Indentation** preferences page (e.g. changing from 4 to 2) and clicking **Close**, the new value is silently discarded. The indent remains at 4, and after quitting and relaunching, the setting reverts entirely.

Additionally, the **`[ ] Use default value`** checkbox is incorrectly shown (and indent controls are disabled) when **`[Default]`** is selected in the Indent Settings list.

### Steps to Reproduce

1. Open Settings / Preferences from the menu
2. Select Indentation / Indent Settings → `[Default]`
3. Uncheck `[ ] Use default value` (this should not be visible for [Default], but is due to the second bug)
4. Set Indent size to `2`
5. Select Indent using → Space character(s)
6. Click `Close`
7. Observe: indent still uses 4 spaces instead of 2
8. Quit and relaunch → the setting has reverted to 4

### Environment

- Nextpad++ version: 1.0.8
- macOS: Tahoe 26.6.1

## Root Cause

**Indent size not persisting:** The indent-size text field's action (`prefChanged:`, tag 100) only fires on Return or when the field ends editing. Clicking the Close button closes the window via `orderOut:` before the field has a chance to commit — so the new value never reaches `NSUserDefaults`.

**Checkbox incorrectly visible:** During page construction, `selectRowIndexes:` on the language table fires the `tableViewSelectionDidChange:` delegate, which calls `_indentLangSelectionChanged:`. That method looks up the options-box controls via `[tv.window.contentView viewWithTag:1320]` — but at construction time the view hierarchy isn't in a window yet, so the lookup returns `nil` and the method exits early without hiding the checkbox or enabling the controls.

## Fix

Two minimal, targeted changes in `PreferencesWindowController.mm`:

1. **`closePrefs:`** — call `[self.window makeFirstResponder:nil]` before `orderOut:` to flush any uncommitted text field edits. This also benefits every other text-field-based preference across all pages (caret blink rate, edge column, backup interval, etc.).

2. **`_buildIndentationPage`** — after building the options box, explicitly set the correct initial state for the `[Default]` selection (hide checkbox, enable controls) rather than relying on the delegate callback that can't find the controls during construction.

## Testing

- Open Preferences → Indentation, select `[Default]`, verify checkbox is hidden and controls are enabled
- Change indent size to 2, select Space character(s), click Close
- Verify the editor uses 2-space indentation
- Quit and relaunch — verify the setting persists
- Switch between `[Default]`, `Normal text`, and specific languages — verify checkbox visibility toggles correctly